### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for the DS7505 temperature sensor.  The originally cod
 category=Sensors
 url=https://github.com/hedrickbt/MillaMilla_DS7505_Library
 architectures=*
-includes=<Wire.h>,MillaMilla_DS7505.h
+includes=MillaMilla_DS7505.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which #include directives should be added to the sketch via **Sketch > Include Library > MillaMilla DS7505 Library**. This field should specify the primary header file(s) of the library. The use of `<Wire.h>` in the `includes` field caused compilation to fail:
```
error: C:\Users\per\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.1\cores\arduino/<Wire.h: Invalid argument

 #include <<Wire.h>>
```
In addition, it is not even necessary to have Wire.h in the list, since all versions of the Arduino IDE that support the `includes` field do not require `#include` directives in the sketch for dependencies of libraries.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format