### PR TITLE
Includes should not include angle brackets

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for the DS7505 temperature sensor.  The originally cod
 category=Sensors
 url=https://github.com/hedrickbt/MillaMilla_DS7505_Library
 architectures=*
-includes=<Wire.h>,MillaMilla_DS7505.h
+includes=Wire.h,MillaMilla_DS7505.h


### PR DESCRIPTION
At the moment "Include Library" generates:
```
#include <<Wire.h>>
#include <MillaMilla_DS7505.h>
```

which is incorrect. Removing the `<` and `>` from around `Wire.h` cures the problem.